### PR TITLE
gitalking 切换到自建的 CORS proxy

### DIFF
--- a/webroot/footer.php
+++ b/webroot/footer.php
@@ -48,6 +48,7 @@
     <script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>
     <script>
     const gitalk = new Gitalk({
+      proxy: 'https://cors.pion1eer.workers.dev/?https://github.com/login/oauth/access_token',
       clientID: '0dc093a9aefa1d501df2',
       clientSecret: '3639aabd1bc6b0d9b543be1f13b6bcb2bf7364af',
       repo: 'UniversalOJ.github.io',


### PR DESCRIPTION
gitalking 官方代码采用了第三方提供的 cors proxy 服务，此服务已于 1 月 31 日终止（see https://github.com/gitalk/gitalk/issues/429）。
我们在 cloudflare worker 上自己搭建了 proxy 服务。